### PR TITLE
fix: use correct path for template and less injection.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,39 +1,46 @@
 'use strict';
 
-var gulp = require('gulp')
-  , browserify = require('browserify')
-  , nunjucksify = require('nunjucksify')
-  , gulpLoadPlugins = require('gulp-load-plugins')
-  , source = require('vinyl-source-stream')
-  , buffer = require('vinyl-buffer')
-  , plugins = gulpLoadPlugins()
-  , del = require('del')
-  , eslint = require('gulp-eslint')
-  , fs = require('fs')
-  , path = require('path')
-  , nunjucks = require('nunjucks')
-  , dateFilter = require('nunjucks-date-filter')
-  , purify = require('gulp-purifycss')
-  , cleanCSS = require('gulp-clean-css')
-  , amphtmlValidator = require('amphtml-validator');
+const gulp = require('gulp');
+const browserify = require('browserify');
+const nunjucksify = require('nunjucksify');
+const source = require('vinyl-source-stream');
+const buffer = require('vinyl-buffer');
+const plugins = require('gulp-load-plugins')();
+const del = require('del');
+const fs = require('fs');
+const path = require('path');
+const nunjucks = require('nunjucks');
+const dateFilter = require('nunjucks-date-filter');
+const amphtmlValidator = require('amphtml-validator');
 
-const cwd = process.cwd();
+const CWD = process.cwd();
+const DEBUG = plugins.util.env.NODE_ENV ? plugins.util.env.NODE_ENV : process.env.NODE_ENV !== "production";
+
 // Command-line and default theme options from theme.json.
-var theme = require(path.resolve(cwd, './theme.json'));
-var node_env = plugins.util.env.NODE_ENV ? plugins.util.env.NODE_ENV : process.env.NODE_ENV;
-const DEBUG = node_env!== "production";
-const inputPath = theme.extends ? `./node_modules/liveblog-${theme.extends}-theme/` : '';
+let theme = {};
+const loadThemeJSON = () => {
+  theme = require(path.resolve(`${CWD}/theme.json`));
+};
+loadThemeJSON();
+
+const inputPath = theme.extends ?
+  path.resolve(`${CWD}/node_modules/liveblog-${theme.extends}-theme/`) :
+  path.resolve(`${CWD}/`);
 
 
-let argvKey = 0,
-  apiHost = '',
-  blogId = '',
-  protocol = '',
-  apiResponse = {
-    posts: {_items: []},
-    stickyPosts: {_items: []}
+let argvKey = 0;
+let apiHost = "";
+let blogId = "";
+let protocol = "";
+let apiResponse = {
+  posts: {
+    _items: []
   },
-  match = [];
+  stickyPosts: {
+    _items: []
+  }
+};
+let match = [];
 
 const http = require('http');
 const https = require('https');
@@ -46,7 +53,6 @@ const https = require('https');
 
 if (argvKey !== 0) {
   match = process.argv[argvKey]
-    //.match(/^(http:\/\/|https:\/\/|\/\/)([^/]+)\/(api\/client_blogs|embed)\/(\w+)/i);
     .match(/^(http:\/\/|https:\/\/|\/\/)([^\/]+)\/(api\/client_blogs|embed|[^\/]+\/blogs)\/(\w+)/i);
 }
 
@@ -100,12 +106,16 @@ if (match.length > 0) {
   });
 }
 
-const templatePath = [
-    path.resolve(__dirname, '../../templates'),
-    path.resolve(__dirname, 'templates')
-  ],
-  nunjucksLoader = new nunjucks.FileSystemLoader(templatePath),
-  nunjucksEnv = new nunjucks.Environment(nunjucksLoader);
+let templatePath = [
+  path.resolve(`${CWD}/templates`)
+];
+
+if (theme.extends) {
+  templatePath.push(path.resolve(`${CWD}/node_modules/liveblog-${theme.extends}-theme/templates`));
+}
+
+const nunjucksLoader = new nunjucks.FileSystemLoader(templatePath);
+const nunjucksEnv = new nunjucks.Environment(nunjucksLoader);
 
 // Add nunjucks-date-filter and set default date format.
 // TODO: get date format from theme settings.
@@ -113,25 +123,24 @@ dateFilter.setDefaultFormat('dddd, MMMM Do, YYYY, h:MM:ss A');
 nunjucksEnv.addFilter('date', dateFilter);
 
 // ampify filter used by AMP theme
-var ampifyFilter = function(html){
+const ampifyFilter = (html) => {
   if (html.search(/iframe/i) > 0) {
     // html contains iframe
-    var src = (/src=\"([^\"]+)\"/).exec(html)[1],
-      width = (/width=\"([^\"]+)\"/).exec(html)[1],
-      height = (/height=\"([^\"]+)\"/).exec(html)[1];
-
-    return [
-      '<amp-iframe width=' + width,
-      'height=' + height,
-      'layout="responsive"',
-      'frameborder="0"',
-      'sandbox="allow-scripts allow-same-origin allow-popups"',
-      'src="' + src + '">',
-      '<p placeholder>Loading...</p>',
-      '</amp-iframe>'
-    ].join(' ');
+    const src = (/src=\"([^\"]+)\"/).exec(html)[1];
+    const width = (/width=\"([^\"]+)\"/).exec(html)[1];
+    const height = (/height=\"([^\"]+)\"/).exec(html)[1];
+    return `
+    <amp-iframe
+        width=${width}
+        height=${height}
+        layout="responsive"
+        frameborder="0"
+        sandbox="allow-scripts
+        allow-same-origin allow-popups"
+        src="${src}">
+            <p placeholder>Loading...</p>
+    </amp-iframe>`;
   }
-  
   return html;
 };
 
@@ -168,32 +177,18 @@ function getThemeSettings(options) {
   return _options;
 }
 
-
-// Function to async reload default theme options.
-function loadThemeJSON() {
-  fs.readFile(path.resolve(cwd, 'theme.json'), 'utf8', (err, data) => {
-    theme = JSON.parse(data);
-  });
-}
-
-gulp.task('lint', () => gulp.src([path.resolve(inputPath, 'js/**/*.js'),path.resolve(inputPath, 'gulpfile.js')])
-  .pipe(eslint({ quiet: true }))
-  .pipe(eslint.format())
-  .pipe(eslint.failAfterError())
+gulp.task('lint', () =>
+  gulp.src([
+    path.resolve(inputPath, 'js/**/*.js'),
+    path.resolve(inputPath, 'gulpfile.js')
+  ])
+  .pipe(plugins.eslint({ quiet: true }))
+  .pipe(plugins.eslint.format())
+  .pipe(plugins.eslint.failAfterError())
 );
-
-//gulp.task('move-templates', () => gulp.src(inputPath + 'templates/*.html')
-//  .pipe(gulp.dest(inputPath + 'templates-dist')));
-
-//gulp.task('move-subtemplates', ['move-templates'], () => gulp.src('./templates/*.html')
-//  .pipe(gulp.dest(inputPath + 'templates-dist')));
 
 // Browserify.
 let browserifyPreviousTasks = ['clean-js'];
-
-//if (process.env.EXTENDED_MODE) {
-//  browserifyPreviousTasks.push('move-subtemplates');
-//}
 
 gulp.task('browserify', browserifyPreviousTasks, (cb) => {
   if (theme.ampTheme) {
@@ -232,8 +227,7 @@ gulp.task('browserify', browserifyPreviousTasks, (cb) => {
     .pipe(gulp.dest('.'));
 });
 
-// Compile LESS files.
-gulp.task('less', ['clean-css'], () => { 
+const lessCommon = (cleanCss) => {
   var lessFiles = [];
   // Name of the less theme file.
   let themeLess = `./less/${theme.name}.less`;
@@ -241,21 +235,27 @@ gulp.task('less', ['clean-css'], () => {
   lessFiles.push(fs.existsSync(themeLess) ? themeLess : './less/*.less');
 
   if ( !theme.onlyOwnCss && theme.extends ) {
-    let themeLess = path.resolve(inputPath,`./less/${theme.extends}.less`);
-    lessFiles.push(fs.existsSync(themeLess) ? themeLess : path.resolve(inputPath,'./less/*.less'));
+    let themeLess = path.resolve(`${inputPath}/less/${theme.extends}.less`);
+    lessFiles.push(fs.existsSync(themeLess) ? themeLess : path.resolve(`${inputPath}/less/*.less`));
   }
 
   return gulp.src(lessFiles)
     .pipe(plugins.less({
       paths: [path.resolve(inputPath, 'less')]
     }))
-    .pipe(plugins.if(!DEBUG, plugins.minifyCss({compatibility: 'ie8'})))
+    .pipe(plugins.if(cleanCss, plugins.purifycss([BUILD_HTML])))
+    .pipe(plugins.if(cleanCss, plugins.cleanCss({compatibility: 'ie8'})));
+};
+
+// Compile LESS files.
+gulp.task('less', ['clean-css'], () =>
+    lessCommon(!DEBUG)
     .pipe(plugins.concat(`${theme.name}.css`))
     .pipe(plugins.rev())
     .pipe(gulp.dest('./dist'))
     .pipe(plugins.rev.manifest('dist/rev-manifest.json', {merge: true}))
-    .pipe(gulp.dest('.'));
-});
+    .pipe(gulp.dest('.'))
+);
 
 
 // Inject API response into template for dev/test purposes.
@@ -269,7 +269,7 @@ gulp.task('index-inject', ['less', 'browserify'], () => {
     testdata.options.api_host = `${protocol}${apiHost}`;
     testdata.options.blog._id = blogId;
   }
-  var index = `./templates/template-index.html`;
+  var index = `${CWD}/templates/template-index.html`;
   var indexTask = gulp.src(fs.existsSync(index) ? index : path.resolve(inputPath,index))
     .pipe(plugins.inject(sources))
     .pipe(plugins.nunjucks.compile({
@@ -282,24 +282,16 @@ gulp.task('index-inject', ['less', 'browserify'], () => {
     }, apiResponse.posts._items.length > 0 ? {} : nunjucksOptions));
 
   if (theme.ampTheme) {
-    let lessFiles = [],
-      themeLess = path.resolve(cwd, `./less/${theme.extends}.less`);
-    lessFiles.push(fs.existsSync(themeLess) ? themeLess : path.resolve(cwd,'./less/*.less'));
 
-    indexTask = indexTask.pipe(gulp.src(lessFiles)
-      .pipe(plugins.less({
-        paths: [path.resolve(inputPath, 'less')]
-      }))
-      .pipe(purify([BUILD_HTML]))
-      .pipe(cleanCSS())
-      .pipe(gulp.dest('./build/amp/'))
-      .pipe(plugins.inject(gulp.src(['./build/amp/*.css']), {
+    indexTask = indexTask.pipe(plugins.inject(
+      lessCommon(true),
+      {
         starttag: '<!-- inject:amp-styles -->',
         transform: function(filepath, file) {
           return file.contents.toString();
         },
         removeTags: true
-      }))
+      })
     );
   }
   return indexTask.pipe(plugins.rename("index.html"))
@@ -345,7 +337,6 @@ gulp.task('template-inject', ['less', 'browserify'], () => {
       include_js_options: false,
       debug: DEBUG
     }))
-
     // Add nunjucks/jinja2 template for server-side processing.
     .pipe(plugins.inject(gulp.src(templates), {
       starttag: '<!-- inject:template-content -->',
@@ -362,7 +353,7 @@ gulp.task('template-inject', ['less', 'browserify'], () => {
 
 // Replace assets paths in theme.json file and reload options.
 gulp.task('theme-replace', ['browserify', 'less'], () => {
-  var manifest = require(path.resolve(cwd, "./dist/rev-manifest.json"));
+  var manifest = require(path.resolve(CWD, "./dist/rev-manifest.json"));
   var base = './',
     cssName = new RegExp(`${theme.name}-.*\.css`, 'g'),
     jsName = new RegExp(`${theme.name}-.*\.js`, 'g');
@@ -376,7 +367,7 @@ gulp.task('theme-replace', ['browserify', 'less'], () => {
   loadThemeJSON();
 });
 
-gulp.task('serve', ['browserify', 'less', 'index-inject'], () => {
+gulp.task('server', ['browserify', 'less', 'index-inject'], () => {
   plugins.connect.server({
     port: 8008,
     root: '.',
@@ -386,7 +377,7 @@ gulp.task('serve', ['browserify', 'less', 'index-inject'], () => {
 });
 
 // Watch
-gulp.task('watch-static', ['serve'], () => {
+gulp.task('watch-static', ['server'], () => {
   var js = gulp.watch(paths.js, ['browserify', 'index-inject'])
     , less = gulp.watch(paths.less, ['less', 'index-inject'])
     , templates = gulp.watch(paths.templates, ['index-inject']);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "gulp-inject": "^4.0.0",
     "gulp-less": "^3.0.5",
     "gulp-load-plugins": "^1.2.0",
-    "gulp-minify-css": "^1.2.1",
     "gulp-ng-annotate": "^2.0.0",
     "gulp-nunjucks": "^3.0.0",
     "gulp-purifycss": "^0.2.0",


### PR DESCRIPTION
### fixed
- [x] amp extensions issues with `gulp watch-static` task.
- [x] less incorrect extended paths.
- [x] templates incorrect extended paths.

### changed 
- [x] renamed `serve` task to proper `server`

### improvements
- [ ] use `const` and `let` instead of `var`.
- [x] `lessCommon` for less tasks.
- [ ] don't use comma for multiple variable declarations
- [ ] don't support multiple variable declarations.