### PR TITLE
[Fix] Update timestamps when loading paginated posts

### DIFF
--- a/js/theme/handlers.js
+++ b/js/theme/handlers.js
@@ -47,6 +47,7 @@ var buttons = {
       viewmodel.loadPostsPage()
         .then(view.renderPosts)
         .then(view.displayNewPosts)
+        .then(view.updateTimestamps)
         .catch(catchError);
     },
     

--- a/js/theme/view.js
+++ b/js/theme/view.js
@@ -343,6 +343,7 @@ function permalinkScroll() {
   if (scrollElem) {
     scrollElem.classList.add('lb-post-permalink-selected');
     scrollElem.scrollIntoView();
+    updateTimestamps();
     return true;
   }
 


### PR DESCRIPTION
Hi folks,

I just noticed, that the timestamps won't be updated to the configured format, if an additional render is triggered, e.g. when loading the next page of paginated posts or jumping to a paginated post via direct link. These are the two single scenarios I'm able to identify at the moment, but it's possible that other ones could profit from the fix as well. 
My approach is just invoking the `updateTimestamps()` function during the rendering procedures in question. Using the `date` filter in the template could  probably present another viable solution at the cost of losing relative time format, of course.
